### PR TITLE
pass the exact tcl library version as linker argument

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,6 +15,11 @@
               "OTHER_LDFLAGS": ["-stdlib=libc++"],
               "MACOSX_DEPLOYMENT_TARGET": "10.7"
             }
+        } ],
+        ["OS=='linux'", {
+			"variables": {
+			         "TCL_LIB" : "-ltcl<!(echo 'puts $tcl_version' | tclsh )",
+            }
         } ]
       ],
       "include_dirs": [
@@ -26,7 +31,7 @@
       ],
       "link_settings": {
         "libraries": [
-          "-ltcl"
+          "<(TCL_LIB)"
         ]
       }
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -14,6 +14,9 @@
               "OTHER_CPLUSPLUSFLAGS" : ["-std=c++11","-stdlib=libc++"],
               "OTHER_LDFLAGS": ["-stdlib=libc++"],
               "MACOSX_DEPLOYMENT_TARGET": "10.7"
+            },
+			"variables": {
+			         "TCL_LIB" : "-ltcl"
             }
         } ],
         ["OS=='linux'", {


### PR DESCRIPTION
gyp build process fails on Linux because the exact Tcl library version needs to be passed (ie `-ltcl8.6' not just `-ltcl`):
```
/usr/bin/ld: cannot find -ltcl
collect2: error: ld returned 1 exit status
make: *** [Release/obj.target/tcl.node] Error 1
make: Leaving directory `/home/ekarak/node_modules/tcl/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
```

Hence a little gyp magic is needed